### PR TITLE
Add "void" as a native return type declaration

### DIFF
--- a/src/DependencyInjection/EasyAdminPrettyUrlsExtension.php
+++ b/src/DependencyInjection/EasyAdminPrettyUrlsExtension.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
  */
 class EasyAdminPrettyUrlsExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);


### PR DESCRIPTION
This fixes a deprecation warning regarding `ExtensionInterface::load()`.

Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "MarcinJozwikowski\EasyAdminPrettyUrls\DependencyInjection\EasyAdminPrettyUrlsExtension" now to avoid errors or add an explicit @return annotation to suppress this message.